### PR TITLE
Update RangePickerComponent to use last chosen range if available

### DIFF
--- a/src/js/component/RangePicker/RangePicker.tsx
+++ b/src/js/component/RangePicker/RangePicker.tsx
@@ -488,8 +488,7 @@ const RangePickerComponent: React.FC<RangePickerComponentProps> = memo(
     useEffect(() => {
       if (show) {
         if (customRanges && customRanges.length > 0) {
-          setChosenRange(customRanges[0].label);
-          handleCustomRangeSelection(customRanges[0].getValue);
+          setChosenRange(lastChosenRange || customRanges[0].label);
         } else {
           setChosenRange(lastChosenRange);
         }


### PR DESCRIPTION
This pull request includes a minor change to the `RangePickerComponent` in `RangePicker.tsx`. The change ensures that the last chosen range is preserved when the component is re-rendered, improving user experience.

* [`src/js/component/RangePicker/RangePicker.tsx`](diffhunk://#diff-8cfd53ba9896414962fc099fbc7f19197b882bed732a313586fd33713bf962e0L491-R491): Modified the `useEffect` hook to set the chosen range to `lastChosenRange` if it exists, or default to the first custom range label.